### PR TITLE
Handle non-alphabetic symbols as individual tokens

### DIFF
--- a/dictator.js
+++ b/dictator.js
@@ -327,10 +327,10 @@
       return text.split(re).filter(s => s.trim().length > 0);
     }
     function splitIntoWords(sentence) {
-      return sentence.match(/[\wа-яА-ЯёЁ\-]+|[.,!?…()"'«»\[\]{}]+/g) || [sentence];
+      return sentence.match(/[\wа-яА-ЯёЁ]+|[^\s\w]/g) || [sentence];
     }
     function isPunctuation(token) {
-      return /^[.,!?…()"'«»\[\]{}]+$/.test(token);
+      return /^[^\wа-яА-ЯёЁ]+$/.test(token);
     }
 
     function isFirstSentence(i) { return i === 0; }


### PR DESCRIPTION
## Summary
- Split sentences into words and individual non-alphabetic characters
- Detect punctuation by checking tokens for non-alphanumeric characters

## Testing
- `node --check dictator.js`


------
https://chatgpt.com/codex/tasks/task_e_68c1d5fb74e0832e96b93985f6d3363c