### PR TITLE
Remove volume and special symbol pause settings

### DIFF
--- a/dictator.css
+++ b/dictator.css
@@ -191,15 +191,17 @@
     .preset-btn {
       -webkit-tap-highlight-color: transparent;
       appearance: none;
+      padding: 10px 14px;
+      border-radius: 12px;
       border: 1px solid var(--border);
-      border-radius: 999px;
-      padding: 10px 16px;
-      font-size: 14px;
-      font-weight: 600;
-      background: var(--surface);
+      background: transparent;
+      color: inherit;
       cursor: pointer;
+      font-weight: 600;
       transition: transform .02s ease, background .2s ease, opacity .2s ease;
     }
+    .preset-btn:hover { background: rgba(0,0,0,.04); }
+    body.night-mode .preset-btn:hover { background: rgba(255,255,255,.06); }
     .preset-btn:active { transform: translateY(1px); }
     .preset-btn[aria-pressed="true"] {
       background: var(--primary);

--- a/dictator.html
+++ b/dictator.html
@@ -60,20 +60,12 @@
             <input type="range" id="aux-speed-control" min="0.1" max="3.0" step="0.1" value="1.0">
           </div>
           <div class="control-group">
-            <label>Громкость: <span id="volume-value">1.0</span></label>
-            <input type="range" id="volume-control" min="0" max="1" step="0.1" value="1.0">
-          </div>
-          <div class="control-group">
             <label>Порог длинного слова (букв): <span id="long-word-threshold-value">7</span></label>
             <input type="range" id="long-word-threshold" min="4" max="15" step="1" value="7">
           </div>
           <div class="control-group">
             <label>Пауза между словами (мс): <span id="word-pause-value">200</span></label>
             <input type="range" id="word-pause-control" min="0" max="3000" step="100" value="200">
-          </div>
-          <div class="control-group">
-            <label>Пауза после спецсимволов (мс): <span id="symbol-pause-value">200</span></label>
-            <input type="range" id="symbol-pause-control" min="0" max="3000" step="100" value="200">
           </div>
           <div class="control-group">
             <label>Размер шрифта (текст): <span id="text-size-value">16px</span></label>
@@ -140,9 +132,9 @@
           <h3>Что важно знать</h3>
           <ul>
             <li><strong>Автосохранение текста</strong>: весь текст автоматически сохраняется в <code>localStorage</code>. При закрытии или перезагрузке вкладки он будет восстановлен.</li>
-            <li><strong>Настройки</strong> (скорости, паузы, громкость, тема, пресеты, размеры шрифтов) сохраняются в cookie на 365 дней.</li>
+            <li><strong>Настройки</strong> (скорости, паузы, тема, пресеты, размеры шрифтов) сохраняются в cookie на 365 дней.</li>
             <li><strong>Знаки препинания</strong>: переключатель «Проговаривать знаки препинания» включает/выключает произношение «Точка», «Запятая» и т.д.</li>
-            <li><strong>Спецсимволы</strong>: переключатель «Проговаривать спецсимволы» управляет произношением «Решётка», «Собака» и т.п., а ползунок «Пауза после спецсимволов» задаёт задержку после них.</li>
+            <li><strong>Спецсимволы</strong>: переключатель «Проговаривать спецсимволы» управляет произношением «Решётка», «Собака» и т.п.</li>
             <li><strong>Подсказки</strong>: при новой строке/абзаце и при «двойных» буквах озвучиваются вспомогательные фразы.</li>
             <li><strong>Совместимость</strong>: работает на десктопе и мобильных устройствах. Учтите системную громкость и беззвучный режим.</li>
             <li><strong>Конфиденциальность</strong>: текст хранится только локально в вашем браузере; для озвучки используется запрос к TTS‑сервису.</li>

--- a/dictator.js
+++ b/dictator.js
@@ -19,14 +19,10 @@
     const slowWordSpeedValue = document.getElementById('slow-word-speed-value');
     const auxSpeedControl = document.getElementById('aux-speed-control');
     const auxSpeedValue = document.getElementById('aux-speed-value');
-    const volumeControl = document.getElementById('volume-control');
-    const volumeValue = document.getElementById('volume-value');
     const longWordThresholdControl = document.getElementById('long-word-threshold');
     const longWordThresholdValue = document.getElementById('long-word-threshold-value');
     const wordPauseControl = document.getElementById('word-pause-control');
     const wordPauseValue = document.getElementById('word-pause-value');
-    const symbolPauseControl = document.getElementById('symbol-pause-control');
-    const symbolPauseValue = document.getElementById('symbol-pause-value');
     const speakSymbolsToggle = document.getElementById('speak-symbols-toggle');
 
     
@@ -203,10 +199,8 @@
         wordSpeed: wordSpeedControl.value,
         slowWordSpeed: slowWordSpeedControl.value,
         auxSpeed: auxSpeedControl.value,
-        volume: volumeControl.value,
         longWordThreshold: longWordThresholdControl.value,
         wordPause: wordPauseControl.value,
-        symbolPause: symbolPauseControl.value,
         voice: voiceSelect.value,
         nightMode: themeToggle.checked,
         textSize: textSizeControl.value,
@@ -227,10 +221,8 @@
         if (settings.wordSpeed) { wordSpeedControl.value = settings.wordSpeed; wordSpeedValue.textContent = settings.wordSpeed + "x"; }
         if (settings.slowWordSpeed) { slowWordSpeedControl.value = settings.slowWordSpeed; slowWordSpeedValue.textContent = settings.slowWordSpeed + "x"; }
         if (settings.auxSpeed) { auxSpeedControl.value = settings.auxSpeed; auxSpeedValue.textContent = settings.auxSpeed + "x"; }
-        if (settings.volume) { volumeControl.value = settings.volume; volumeValue.textContent = settings.volume; }
         if (settings.longWordThreshold) { longWordThresholdControl.value = settings.longWordThreshold; longWordThresholdValue.textContent = settings.longWordThreshold; }
         if (settings.wordPause) { wordPauseControl.value = settings.wordPause; wordPauseValue.textContent = settings.wordPause; }
-        if (settings.symbolPause) { symbolPauseControl.value = settings.symbolPause; symbolPauseValue.textContent = settings.symbolPause; }
         if (settings.voice) { voiceSelect.value = settings.voice; }
         if (typeof settings.nightMode === 'boolean') { themeToggle.checked = settings.nightMode; document.body.classList.toggle('night-mode', settings.nightMode); }
         if (settings.textSize) { textSizeControl.value = settings.textSize; textSizeValue.textContent = settings.textSize + "px"; textInput.style.fontSize = settings.textSize + "px"; }
@@ -249,10 +241,8 @@
       wordSpeedControl.value = "1.0";       wordSpeedValue.textContent = "1.0x";
       slowWordSpeedControl.value = "0.5";   slowWordSpeedValue.textContent = "0.5x";
       auxSpeedControl.value = "1.0";        auxSpeedValue.textContent = "1.0x";
-      volumeControl.value = "1.0";          volumeValue.textContent = "1.0";
       longWordThresholdControl.value = "7"; longWordThresholdValue.textContent = "7";
       wordPauseControl.value = "200";       wordPauseValue.textContent = "200";
-      symbolPauseControl.value = "200";    symbolPauseValue.textContent = "200";
       voiceSelect.value = "zahar";
       textSizeControl.value = "16"; textSizeValue.textContent = "16px"; textInput.style.fontSize = "16px";
       dictationSizeControl.value = "48"; dictationSizeValue.textContent = "48px"; sentenceContent.style.fontSize = "48px";
@@ -269,10 +259,8 @@
     wordSpeedControl.addEventListener('input', () => { wordSpeedValue.textContent = wordSpeedControl.value + 'x'; saveSettingsToCookies(); clearActivePreset(); });
     slowWordSpeedControl.addEventListener('input', () => { slowWordSpeedValue.textContent = slowWordSpeedControl.value + 'x'; saveSettingsToCookies(); clearActivePreset(); });
     auxSpeedControl.addEventListener('input', () => { auxSpeedValue.textContent = auxSpeedControl.value + 'x'; saveSettingsToCookies(); clearActivePreset(); });
-    volumeControl.addEventListener('input', () => { volumeValue.textContent = volumeControl.value; saveSettingsToCookies(); });
     longWordThresholdControl.addEventListener('input', () => { longWordThresholdValue.textContent = longWordThresholdControl.value; saveSettingsToCookies(); clearActivePreset(); });
     wordPauseControl.addEventListener('input', () => { wordPauseValue.textContent = wordPauseControl.value; saveSettingsToCookies(); clearActivePreset(); });
-    symbolPauseControl.addEventListener('input', () => { symbolPauseValue.textContent = symbolPauseControl.value; saveSettingsToCookies(); clearActivePreset(); });
     voiceSelect.addEventListener('change', () => { saveSettingsToCookies(); });
     themeToggle.addEventListener('change', () => { document.body.classList.toggle('night-mode', themeToggle.checked); saveSettingsToCookies(); });
     if (speakPunctToggle) speakPunctToggle.addEventListener('change', () => { saveSettingsToCookies(); });
@@ -400,7 +388,6 @@
       yandexTtsPlay(
         sentence,
         parseFloat(sentenceSpeedControl.value),
-        parseFloat(volumeControl.value),
         voice,
         () => {
           if (!speechStopped) {
@@ -452,7 +439,6 @@
               yandexTtsPlay(
                 prependText,
                 parseFloat(auxSpeedControl.value),
-                parseFloat(volumeControl.value),
                 voiceSelect.value,
                 () => { cb(); }
               );
@@ -463,7 +449,6 @@
               yandexTtsPlay(
                 'С большой буквы',
                 parseFloat(auxSpeedControl.value),
-                parseFloat(volumeControl.value),
                 voiceSelect.value,
                 () => { cb(); }
               );
@@ -481,7 +466,6 @@
               yandexTtsPlay(
                 token,
                 parseFloat(wordSpeedControl.value),
-                parseFloat(volumeControl.value),
                 voiceSelect.value,
                 () => {
                   const aux = getAuxExpressions(token);
@@ -489,7 +473,6 @@
                     yandexTtsPlay(
                       token,
                       parseFloat(slowWordSpeedControl.value),
-                      parseFloat(volumeControl.value),
                       voiceSelect.value,
                       () => { unhighlightWord(wordIndex); cb(); }
                     );
@@ -500,7 +483,6 @@
               yandexTtsPlay(
                 token,
                 parseFloat(wordSpeedControl.value),
-                parseFloat(volumeControl.value),
                 voiceSelect.value,
                 () => { unhighlightWord(wordIndex); const aux = getAuxExpressions(token); speakAuxExpressions(aux, () => { cb(); }); }
               );
@@ -518,8 +500,7 @@
                 if (nextI < words.length) {
                   const nextTok = words[nextI];
                   if (symbolSpoken) {
-                    const pause = parseInt(symbolPauseControl.value, 10) || 0;
-                    schedulePauseable(() => { wordIndex++; speakNext(); }, pause);
+                    schedulePauseable(() => { wordIndex++; speakNext(); }, 200);
                   } else if (isSymbolTok && !symbolSpoken) {
                     wordIndex++; speakNext();
                   } else if (isRegPunctTok && isPunctuation(nextTok)) {
@@ -538,7 +519,7 @@
     }
 
     // TTS-прокси
-    function yandexTtsPlay(text, speed, volume, voice, callback) {
+    function yandexTtsPlay(text, speed, voice, callback) {
       if (!text || !text.trim()) { callback(); return; }
       if (speed < 0.1) speed = 0.1; if (speed > 3.0) speed = 3.0;
       fetch(GLITCH_TTS_URL, {
@@ -550,7 +531,6 @@
       .then(blob => {
         const url = URL.createObjectURL(blob);
         const audio = new Audio(url);
-        audio.volume = volume;
         audio.onended = () => { if (activeAudio === audio) activeAudio = null; callback(); };
         audio.onerror = () => { if (activeAudio === audio) activeAudio = null; callback(); };
         activeAudio = audio;
@@ -563,12 +543,12 @@
 
     function speakAuxExpressions(expressions, cb) {
       if (!expressions || expressions.length === 0) { cb(); return; }
-      let i = 0; (function next(){ if (i >= expressions.length) { cb(); return; } const text = expressions[i]; yandexTtsPlay(text, parseFloat(auxSpeedControl.value), parseFloat(volumeControl.value), voiceSelect.value, () => { i++; next(); }); })();
+      let i = 0; (function next(){ if (i >= expressions.length) { cb(); return; } const text = expressions[i]; yandexTtsPlay(text, parseFloat(auxSpeedControl.value), voiceSelect.value, () => { i++; next(); }); })();
     }
     function speakPunctuation(punct, index, cb) {
       const map = typeof PUNCTUATION_MAP !== 'undefined' ? PUNCTUATION_MAP : {};
       const txt = map[punct] || punct;
-      yandexTtsPlay(txt, parseFloat(auxSpeedControl.value), parseFloat(volumeControl.value), voiceSelect.value, () => { unhighlightWord(index); cb(); });
+      yandexTtsPlay(txt, parseFloat(auxSpeedControl.value), voiceSelect.value, () => { unhighlightWord(index); cb(); });
     }
 
     function highlightWord(i) { const sp = document.getElementById(`word-${i}`); if (sp) sp.classList.add('highlight'); }
@@ -602,7 +582,7 @@
     function resetProgressBar() { progressBar.style.width = '0%'; }
 
     function playNotificationSound() { const audio = new Audio('https://www.soundjay.com/misc/sounds/bell-ringing-05.mp3'); audio.play().catch(e => console.error('bell error', e)); }
-    function speakFinalExpression() { yandexTtsPlay('Конспект окончен', parseFloat(auxSpeedControl.value), parseFloat(volumeControl.value), voiceSelect.value, () => { restoreOriginalText(); }); }
+    function speakFinalExpression() { yandexTtsPlay('Конспект окончен', parseFloat(auxSpeedControl.value), voiceSelect.value, () => { restoreOriginalText(); }); }
 
     // При загрузке — восстановить настройки и текст
     loadSettingsFromCookies();


### PR DESCRIPTION
## Summary
- drop redundant volume and special symbol pause controls
- match preset button appearance to action buttons for better night theme visibility
- apply fixed 200 ms pause after spoken special symbols

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c1fc57a888832ea3ece0f6db3b02a9