### PR TITLE
Update normal preset parameters

### DIFF
--- a/__tests__/dictator.test.js
+++ b/__tests__/dictator.test.js
@@ -96,6 +96,37 @@ describe('dictator core functions', () => {
     expect(longWordThresholdValue.textContent).toBe('9');
   });
 
+  test('applyPreset updates controls for normal preset', () => {
+    const { applyPreset } = moduleExports;
+    const sentenceSpeedControl = document.getElementById('sentence-speed-control');
+    const sentenceSpeedValue = document.getElementById('sentence-speed-value');
+    const wordSpeedControl = document.getElementById('word-speed-control');
+    const wordSpeedValue = document.getElementById('word-speed-value');
+    const slowWordSpeedControl = document.getElementById('slow-word-speed-control');
+    const slowWordSpeedValue = document.getElementById('slow-word-speed-value');
+    const auxSpeedControl = document.getElementById('aux-speed-control');
+    const auxSpeedValue = document.getElementById('aux-speed-value');
+    const wordPauseControl = document.getElementById('word-pause-control');
+    const wordPauseValue = document.getElementById('word-pause-value');
+    const longWordThresholdControl = document.getElementById('long-word-threshold');
+    const longWordThresholdValue = document.getElementById('long-word-threshold-value');
+
+    applyPreset('normal');
+
+    expect(sentenceSpeedControl.value).toBe('1.2');
+    expect(sentenceSpeedValue.textContent).toBe('1.2x');
+    expect(wordSpeedControl.value).toBe('0.7');
+    expect(wordSpeedValue.textContent).toBe('0.7x');
+    expect(slowWordSpeedControl.value).toBe('0.6');
+    expect(slowWordSpeedValue.textContent).toBe('0.6x');
+    expect(auxSpeedControl.value).toBe('1.2');
+    expect(auxSpeedValue.textContent).toBe('1.2x');
+    expect(wordPauseControl.value).toBe('1200');
+    expect(wordPauseValue.textContent).toBe('1200');
+    expect(longWordThresholdControl.value).toBe('9');
+    expect(longWordThresholdValue.textContent).toBe('9');
+  });
+
   test('schedulePauseable respects pause and resume', () => {
     const { schedulePauseable, pauseAll, resumeAll } = moduleExports;
     const spy = jest.fn();

--- a/dictator.js
+++ b/dictator.js
@@ -88,7 +88,7 @@
     function applyPreset(name) {
       const presets = {
         slow:   { sentenceSpeed: 0.9, wordSpeed: 0.85, slowWordSpeed: 0.6, auxSpeed: 0.9, wordPause: 260, longWordThreshold: 6 },
-        normal: { sentenceSpeed: 1.0, wordSpeed: 1.0,  slowWordSpeed: 0.5, auxSpeed: 1.0, wordPause: 200, longWordThreshold: 7 },
+        normal: { sentenceSpeed: 1.2, wordSpeed: 0.7,  slowWordSpeed: 0.6, auxSpeed: 1.2, wordPause: 1200, longWordThreshold: 9 },
         fast:   { sentenceSpeed: 1.15, wordSpeed: 1.2, slowWordSpeed: 0.8, auxSpeed: 1.2, wordPause: 120, longWordThreshold: 9 }
       };
       const p = presets[name]; if (!p) return;


### PR DESCRIPTION
## Summary
- Adjust "normal" preset to 1.2 sentence speed, 0.7 word speed, 0.6 long-word speed, 1.2 aux speed, 1200 ms pause, 9-letter threshold
- Add test covering updated normal preset values

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c4e77b9a68832ea668c321ae2e3f72