### PR TITLE
Tweak book title styling for secondary emphasis

### DIFF
--- a/dictator/dt-app.css
+++ b/dictator/dt-app.css
@@ -28,9 +28,12 @@ body {
   text-align: center;
 }
 .book-title {
-  font-size: 1.2rem;
+  font-size: 1rem;
   text-align: center;
-  font-weight: bold;
+  font-weight: 500;
+  color: #666;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
   margin-bottom: 1rem;
 }
 .question {


### PR DESCRIPTION
## Summary
- soften the book title styling to reduce its prominence relative to the question prompt

## Testing
- Tests not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d1ea392b44832eb36ada40955b822d