### PR TITLE
Add DITR transcription and PDF export web app

### DIFF
--- a/dictator/ditr-app.html
+++ b/dictator/ditr-app.html
@@ -1,0 +1,293 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>DITR: Расшифровка аудио и экспорт в PDF</title>
+  <style>
+    :root {
+      font-size: 16px;
+      font-family: "Inter", "Segoe UI", system-ui, sans-serif;
+      background: #eef1f7;
+      color: #1f2933;
+    }
+
+    body {
+      margin: 0;
+      padding: 2.5rem 1rem 3rem;
+      display: flex;
+      justify-content: center;
+    }
+
+    .app-shell {
+      width: min(720px, 100%);
+      background: #ffffff;
+      box-shadow: 0 24px 64px rgba(15, 23, 42, 0.12);
+      border-radius: 18px;
+      padding: 2.5rem 2.25rem;
+      box-sizing: border-box;
+    }
+
+    h1 {
+      margin: 0 0 1.25rem;
+      font-size: clamp(1.75rem, 2vw + 1rem, 2.3rem);
+      text-align: center;
+      letter-spacing: 0.04em;
+    }
+
+    p.lead {
+      margin: 0 0 1.75rem;
+      text-align: center;
+      color: #4b5563;
+      font-size: 1rem;
+      line-height: 1.6;
+    }
+
+    label {
+      display: block;
+      font-weight: 600;
+      margin-bottom: 0.5rem;
+      color: #111827;
+    }
+
+    input[type="file"],
+    input[type="password"],
+    textarea {
+      width: 100%;
+      font-size: 1rem;
+      padding: 0.85rem 1rem;
+      border-radius: 10px;
+      border: 1px solid #d1d5db;
+      box-sizing: border-box;
+      transition: border-color 0.2s ease, box-shadow 0.2s ease;
+      background: #f9fafb;
+    }
+
+    input[type="file"] {
+      padding: 0.55rem 0.8rem;
+      background: #fff;
+    }
+
+    input:focus,
+    textarea:focus {
+      border-color: #3b82f6;
+      outline: none;
+      box-shadow: 0 0 0 4px rgba(59, 130, 246, 0.15);
+      background: #fff;
+    }
+
+    textarea {
+      resize: vertical;
+      min-height: 180px;
+      line-height: 1.5;
+      color: #1f2937;
+    }
+
+    button {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      gap: 0.35rem;
+      width: 100%;
+      padding: 0.95rem 1.25rem;
+      margin-top: 1.3rem;
+      font-size: 1rem;
+      font-weight: 600;
+      color: #ffffff;
+      background: linear-gradient(135deg, #2563eb, #1d4ed8);
+      border: none;
+      border-radius: 12px;
+      cursor: pointer;
+      transition: transform 0.18s ease, box-shadow 0.18s ease, filter 0.18s ease;
+    }
+
+    button:hover:not(:disabled) {
+      transform: translateY(-1px);
+      box-shadow: 0 16px 32px rgba(37, 99, 235, 0.25);
+    }
+
+    button:disabled {
+      opacity: 0.6;
+      cursor: not-allowed;
+      box-shadow: none;
+    }
+
+    .status-box {
+      margin-top: 1rem;
+      min-height: 1.5rem;
+      font-size: 0.95rem;
+      color: #4b5563;
+    }
+
+    .status-box.error {
+      color: #dc2626;
+      font-weight: 600;
+    }
+
+    .field {
+      margin-bottom: 1.5rem;
+    }
+
+    .note {
+      font-size: 0.9rem;
+      color: #6b7280;
+      margin-top: 0.5rem;
+      line-height: 1.5;
+    }
+
+    footer {
+      margin-top: 2rem;
+      font-size: 0.85rem;
+      color: #9ca3af;
+      text-align: center;
+      line-height: 1.5;
+    }
+  </style>
+  <script src="https://cdn.jsdelivr.net/npm/jspdf@2.5.1/dist/jspdf.umd.min.js" integrity="sha384-2H0eAV/QXpVZl8vGeOawxDFUY8ailqXF/w3vGN9VOGBev5nYeD1yfknhk+aoCA8X" crossorigin="anonymous"></script>
+</head>
+<body>
+  <main class="app-shell">
+    <h1>DITR • Стенография аудио → PDF</h1>
+    <p class="lead">
+      Загрузите аудио, расшифруйте его через самую продвинутую модель Whisper-совместимого стека OpenAI, а затем экспортируйте дословный текст в формат PDF.
+    </p>
+
+    <section class="field">
+      <label for="audioInput">Аудиофайл (MP3, WAV, M4A, ...)</label>
+      <input id="audioInput" type="file" accept="audio/*" />
+      <p class="note">Файл будет отправлен в OpenAI API для облачной обработки. Соблюдайте лимиты размера и политику безопасности.</p>
+    </section>
+
+    <section class="field">
+      <label for="apiKey">OpenAI API Key</label>
+      <input id="apiKey" type="password" placeholder="sk-..." autocomplete="off" />
+      <p class="note">
+        Для продакшена настройте защищённый бэкенд-прокси и не храните ключи в клиентском коде.
+      </p>
+    </section>
+
+    <button id="transcribeBtn" type="button">1. Расшифровать аудио (OpenAI Whisper)</button>
+    <div id="status" class="status-box"></div>
+
+    <section class="field">
+      <label for="transcriptOutput">Результат транскрибации</label>
+      <textarea id="transcriptOutput" placeholder="Здесь появится дословная стенограмма." readonly></textarea>
+    </section>
+
+    <button id="pdfBtn" type="button" disabled>2. Экспортировать стенограмму в PDF</button>
+
+    <footer>
+      Версия 1.0 • Использует конечную точку <code>/v1/audio/transcriptions</code> и модель <strong>gpt-4o-transcribe</strong>.
+    </footer>
+  </main>
+
+  <script>
+    const audioInput = document.getElementById("audioInput");
+    const apiKeyInput = document.getElementById("apiKey");
+    const transcribeBtn = document.getElementById("transcribeBtn");
+    const pdfBtn = document.getElementById("pdfBtn");
+    const transcriptOutput = document.getElementById("transcriptOutput");
+    const statusBox = document.getElementById("status");
+
+    function setStatus(message, isError = false) {
+      statusBox.textContent = message;
+      statusBox.classList.toggle("error", Boolean(isError));
+    }
+
+    function enablePDFButton(enable) {
+      pdfBtn.disabled = !enable;
+    }
+
+    function exportTranscriptToPDF() {
+      const text = transcriptOutput.value.trim();
+
+      if (!text) {
+        setStatus("Нет текста для сохранения в PDF.", true);
+        return;
+      }
+
+      const { jsPDF } = window.jspdf;
+      const doc = new jsPDF({
+        orientation: "portrait",
+        unit: "pt",
+        format: "a4"
+      });
+
+      const margin = 48;
+      const maxWidth = doc.internal.pageSize.getWidth() - margin * 2;
+      const wrappedText = doc.splitTextToSize(text, maxWidth);
+
+      doc.setFont("Times", "Normal");
+      doc.setFontSize(12);
+      doc.text(wrappedText, margin, margin);
+      doc.save("transcript.pdf");
+
+      setStatus("PDF успешно сохранён.");
+    }
+
+    async function transcribeAudio() {
+      const file = audioInput.files?.[0];
+      const apiKey = apiKeyInput.value.trim();
+
+      if (!file) {
+        setStatus("Пожалуйста, выберите аудиофайл.", true);
+        return;
+      }
+
+      if (!apiKey) {
+        setStatus("Введите OpenAI API ключ или настройте бэкенд-прокси.", true);
+        return;
+      }
+
+      setStatus("Загружаем и расшифровываем аудио, пожалуйста подождите…");
+      enablePDFButton(false);
+
+      try {
+        const formData = new FormData();
+        formData.append("file", file);
+        formData.append("model", "gpt-4o-transcribe");
+        formData.append("response_format", "text");
+
+        const response = await fetch("https://api.openai.com/v1/audio/transcriptions", {
+          method: "POST",
+          headers: {
+            Authorization: `Bearer ${apiKey}`
+          },
+          body: formData
+        });
+
+        if (!response.ok) {
+          let errorMessage = `${response.status} ${response.statusText}`;
+
+          try {
+            const errorPayload = await response.json();
+            if (errorPayload?.error?.message) {
+              errorMessage = errorPayload.error.message;
+            }
+          } catch (jsonError) {
+            // ignore JSON parse errors and fall back to status text
+          }
+
+          throw new Error(errorMessage);
+        }
+
+        const transcriptText = (await response.text()).trim();
+        transcriptOutput.value = transcriptText;
+
+        if (transcriptText) {
+          setStatus("Готово! Стенограмма получена.");
+          enablePDFButton(true);
+        } else {
+          setStatus("Получен пустой ответ. Убедитесь, что аудио содержит речь.", true);
+        }
+      } catch (error) {
+        console.error("Transcription error", error);
+        setStatus(`Ошибка транскрибации: ${error.message}`, true);
+      }
+    }
+
+    transcribeBtn.addEventListener("click", transcribeAudio);
+    pdfBtn.addEventListener("click", exportTranscriptToPDF);
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add the ditr-app.html page that powers the DITR audio transcription workflow
- connect the interface to OpenAI's gpt-4o-transcribe model and enable PDF export via jsPDF
- style the experience with a polished single-page layout and status handling

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d32512cebc832ea1718f881843259a