### PR TITLE
Handle unsupported voice fallback and show TTS errors

### DIFF
--- a/dictator.css
+++ b/dictator.css
@@ -136,6 +136,7 @@
 
     #indicator { display: none; margin-top: 8px; font-size: 15px; color: #FF7A45; opacity: 0; height: auto; transition: opacity .3s; text-align: center; }
     #indicator.visible { display: block; opacity: 1; }
+    #indicator.error { color: #ff4d4f; font-weight: 600; }
 
     /* ====== Спойлер «Настройки» ====== */
     details.settings {


### PR DESCRIPTION
## Summary
- normalize saved voice values, warn once when falling back to supported voices, and reset the flag when the user changes voices
- centralize indicator handling so prepend cues and error messages share the same helper, and display fetch/audio failures to the user with parsed error text
- add styling for the error indicator state to make TTS problems visually distinct

## Testing
- node --check dictator.js

------
https://chatgpt.com/codex/tasks/task_e_68d386bb5b7c832ea90e1b8eb58f68e6